### PR TITLE
Update the contributors command to "contributors.add"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project follows the [all contributors][all-contributors] specification. To 
 contributors on the README.md, please use the automated script as part of your PR:
 
 ```console
-npm start "addContributor <YOUR_GITHUB_USERNAME>"
+npm start "contributors.add"
 ```
 
 Follow the prompt. If you've already added yourself to the list and are making a new type of contribution, you can run


### PR DESCRIPTION
I noticed that `npm start "addContributor CompuIves"` didn't work, but `npm start "contributors.add"` does. This updates the documentation for it.